### PR TITLE
Added configurable color selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,14 @@ nnoremap <leader>c :TextHighlighterClearAll<CR>
 Put settings like below to your keybinding file.
 
 ```
-{ "keys": ["ctrl+super+j"], "command": "text_highlighter_toggle" }
+{ "keys": ["ctrl+super+j"], "command": "text_highlighter_toggle" }`
+{ "keys": ["ctrl+super+j"], "command": "text_highlighter_toggle", "args": { "color": "markup.changed.git_gutter"} }
 { "keys": ["ctrl+super+h"], "command": "text_highlighter_clear_all" }
 ```
+
+### Available colors by scope
+
+`[ markup.changed.git_gutter, support.class, markup.deleted.git_gutter, markup.inserted.git_gutter, constant.numeric, constant.character.escape, variable, string, comment ] `
 
 ## Inspired
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ nnoremap <leader>c :TextHighlighterClearAll<CR>
 Put settings like below to your keybinding file.
 
 ```
-{ "keys": ["ctrl+super+j"], "command": "text_highlighter_toggle" }`
+{ "keys": ["ctrl+super+j"], "command": "text_highlighter_toggle" }
 { "keys": ["ctrl+super+j"], "command": "text_highlighter_toggle", "args": { "color": "markup.changed.git_gutter"} }
 { "keys": ["ctrl+super+h"], "command": "text_highlighter_clear_all" }
 ```

--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ Put settings like below to your keybinding file.
 
 ```
 { "keys": ["ctrl+super+j"], "command": "text_highlighter_toggle" }
+// use specific color as below
 { "keys": ["ctrl+super+j"], "command": "text_highlighter_toggle", "args": { "color": "markup.changed.git_gutter"} }
+
 { "keys": ["ctrl+super+h"], "command": "text_highlighter_clear_all" }
 ```
 

--- a/highlighter.py
+++ b/highlighter.py
@@ -6,7 +6,7 @@ from collections import OrderedDict
 
 class TextHighlighterToggleCommand(sublime_plugin.WindowCommand):
   # TODO: run this command when new tab is opened
-  def run(self):
+  def run(self, color=None):
     active_view = self.window.active_view()
     selected_region = active_view.sel()
     sel_string = active_view.substr(selected_region[0])
@@ -22,7 +22,8 @@ class TextHighlighterToggleCommand(sublime_plugin.WindowCommand):
       for view in views:
         eraser(view, sel_string, color)
     else:
-      color = find_usable_color(self.window, sel_string)
+      if not color:
+          color = find_usable_color(self.window, sel_string)
       for view in views:
         highlighter(view, sel_string, color)
 


### PR DESCRIPTION
Added configurable color selector while defining commands/hotkeys. Previously a random available color was used. Now one can specify the color([colors are mapped based on scope](https://www.sublimetext.com/docs/scope_naming.html))
```json
{
    "keys": [ "ctrl+super+j" ],
    "command": "text_highlighter_toggle",
    "args": {
        "color": "markup.changed.git_gutter" <----additionaly specify the color argument
    }
}
```